### PR TITLE
Added setters for log enablement, all-log enablement, and log level.

### DIFF
--- a/attrs.go
+++ b/attrs.go
@@ -1,18 +1,21 @@
 package logger
 
+// Attrs is a key-value type used to pass structured logging data to Logger instances.
 type Attrs map[string]interface{}
 
+// SplitAttrs checks if the last item passed in v is an Attrs instance,
+// if so it returns it separately. If not, v is returned as-is with a nil Attrs.
 func SplitAttrs(v ...interface{}) ([]interface{}, *Attrs) {
 	if len(v) == 0 {
 		return v, nil
 	}
 
-	attrs, ok := v[len(v) -1].(Attrs)
+	attrs, ok := v[len(v)-1].(Attrs)
 
 	if !ok {
 		return v, nil
 	}
 
-	v = v[:len(v) - 1]
+	v = v[:len(v)-1]
 	return v, &attrs
 }

--- a/logger.go
+++ b/logger.go
@@ -18,12 +18,22 @@ func New(name string) *Logger {
 	}
 }
 
+// Checks whether this logger is enabled, sets self.IsEnabled, and returns the value.
+// This is a little kludgy but was introduced to allow dynamic log-name/log-level
+// changes to be made by programs at runtime. IsEnabled property is retained for API
+// compatibility.
+func (l *Logger) amIEnabled() bool {
+	e := IsEnabled(l.Name)
+	l.IsEnabled = e
+	return e
+}
+
 func (l *Logger) Info(format string, v ...interface{}) {
 	if verbosity > 1 {
 		return
 	}
 
-	if !l.IsEnabled {
+	if !l.amIEnabled() {
 		return
 	}
 
@@ -36,12 +46,12 @@ func (l *Logger) Timer() *Timer {
 	return &Timer{
 		Logger:    l,
 		Start:     Now(),
-		IsEnabled: l.IsEnabled && verbosity < 3,
+		IsEnabled: l.amIEnabled() && verbosity < 3,
 	}
 }
 
 func (l *Logger) Error(format string, v ...interface{}) {
-	if !l.IsEnabled {
+	if !l.amIEnabled() {
 		return
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -4,36 +4,55 @@ import (
 	"fmt"
 )
 
+// Logger is the unit of the logger package, a smart, pretty-printing gate between
+// the program and the output stream.
 type Logger struct {
-	Name      string
-	IsEnabled bool
-	Color     string
+	// Name by which the logger is identified when enabling or disabling it, and by envvar.
+	Name string
+	// Color is chosen automatically. It is a terminal escape code, not a color name.
+	Color string
 }
 
+// New returns a logger bound to the given name. It will only be active when
+// the name is enabled in the global Enabled map, which can be done using the
+// LOG=<names> environment variable, or by manually setting it true in the Enabled map.
+// At time of creation this adds a false value for its name to Enabled if no value
+// already exists; in other words, it defaults to disabled. This may cause a
+// race condition in Enabled, however, if another goroutine is accessing the Map.
 func New(name string) *Logger {
+	// Ensure there's an entry, but if not yet true then no env-var has yet enabled
+	// it so default to disabled.
+	if _, ok := Enabled[name]; !ok {
+		Enabled[name] = false
+	}
 	return &Logger{
-		Name:      name,
-		IsEnabled: IsEnabled(name),
-		Color:     nextColor(),
+		Name:  name,
+		Color: nextColor(),
 	}
 }
 
-// Checks whether this logger is enabled, sets self.IsEnabled, and returns the value.
-// This is a little kludgy but was introduced to allow dynamic log-name/log-level
-// changes to be made by programs at runtime. IsEnabled property is retained for API
-// compatibility.
-func (l *Logger) amIEnabled() bool {
-	e := IsEnabled(l.Name)
-	l.IsEnabled = e
-	return e
+// IsEnabled checks whether this logger is enabled in the global roster
+// (logger.Enabled map), or enabled due to logger.AllEnabled being set to true.
+func (l *Logger) IsEnabled() bool {
+	if AllEnabled {
+		return true
+	}
+
+	value, ok := Enabled[l.Name]
+	if !ok {
+		return false
+	}
+	return value
 }
 
+// Info prints log information to the screen that is informational in nature; it
+// is the most verbose level (1) and is disabled at verbosity levels 2 and 3.
 func (l *Logger) Info(format string, v ...interface{}) {
-	if verbosity > 1 {
+	if Verbosity > 1 {
 		return
 	}
 
-	if !l.amIEnabled() {
+	if !l.IsEnabled() {
 		return
 	}
 
@@ -42,16 +61,21 @@ func (l *Logger) Info(format string, v ...interface{}) {
 	l.Output(1, "INFO", fmt.Sprintf(format, v...), attrs)
 }
 
+// Timer returns a timer sub-logger. Timers have verbosity level 2, they are
+// considered a higher priority than Info and lower than Error.
+// If a logger was disabled when a timer is created, the timer remains disabled
+// even if the logger is enabled during the timer's lifespan.
 func (l *Logger) Timer() *Timer {
 	return &Timer{
 		Logger:    l,
 		Start:     Now(),
-		IsEnabled: l.amIEnabled() && verbosity < 3,
+		IsEnabled: l.IsEnabled() && Verbosity < 3,
 	}
 }
 
+// Error logs an error message using fmt. It has log-level 3, the highest level.
 func (l *Logger) Error(format string, v ...interface{}) {
-	if !l.amIEnabled() {
+	if !l.IsEnabled() {
 		return
 	}
 
@@ -60,6 +84,8 @@ func (l *Logger) Error(format string, v ...interface{}) {
 	l.Output(3, "ERROR", fmt.Sprintf(format, v...), attrs)
 }
 
+// Output is the lower-level call delegated to by Info/Timer/Error, and can be used
+// to directly write to the underlying buffer regardless of log-level.
 func (l *Logger) Output(verbosity int, sort string, msg string, attrs *Attrs) {
 	l.Write(l.Format(verbosity, sort, msg, attrs))
 }

--- a/settings.go
+++ b/settings.go
@@ -1,17 +1,28 @@
 package logger
 
 import (
+	"errors"
 	"os"
 	"strings"
 )
 
 var (
 	out                 = os.Stderr
-	verbosity           = Verbosity()
-	enabled, allEnabled = Enabled()
+	verbosity           = initVerbosity()
+	enabled, allEnabled = initEnabled()
 )
 
+// Enabled - Returns the map representing enabled logs, and whether all loggers are
+// enabled regardless of name. These are initialised from environment variables
+// at start-up.
 func Enabled() (map[string]bool, bool) {
+	return enabled, allEnabled
+}
+
+// initEnabled - Gets the LOG environment variable, splits on commas, and stores the
+// values as loggers that are permitted to print. Does not validate that loggers
+// exist; typos may break loggers silently.
+func initEnabled() (map[string]bool, bool) {
 	val := os.Getenv("LOG")
 
 	if val == "*" {
@@ -22,35 +33,70 @@ func Enabled() (map[string]bool, bool) {
 	keys := strings.Split(val, ",")
 
 	for _, key := range keys {
-		all[key] = true
+		// Trim in case people pass space-gapped names.
+		all[strings.TrimSpace(key)] = true
 	}
 
 	return all, false
 }
 
+// IsEnabled - Returns whether a given logger is present and enabled.
 func IsEnabled(name string) bool {
 	if allEnabled {
 		return true
 	}
 
-	_, ok := enabled[name]
-	return ok
+	value, ok := enabled[name]
+	if !ok {
+		return false
+	}
+	return value
 }
 
-func Verbosity() int {
-	level := os.Getenv("LOG_LEVEL")
+// SetEnabled - Enable or Disable loggers by name.
+func SetEnabled(name string, state bool) {
+	enabled[name] = state
+}
 
-	if strings.ToUpper(level) == "TIMER" {
-		return 2
-	}
+// SetAllEnabled - Enable or Disable *all* loggers.
+// NB: This does not change the status of individual loggers, only whether *all*
+// loggers should be allowed print. In other words, setting this to 'false' does
+// not disable loggers that are permitted to print, only those that are not.
+func SetAllEnabled(state bool) {
+	allEnabled = state
+}
 
-	if strings.ToUpper(level) == "ERROR" {
+// Populates default value of 'verbosity' variable from Envvar.
+func initVerbosity() int {
+	switch strings.ToUpper(os.Getenv("LOG_LEVEL")) {
+	case "ERROR":
 		return 3
+	case "TIMER":
+		return 2
+	default:
+		return 1
 	}
-
-	return 1
 }
 
+// Verbosity - Get the value of the LOG_LEVEL environment variable, converted to an integer.
+// Default/Invalid value is 1. If "TIMER", this is 2. If "ERROR", this is 3.
+func Verbosity() int {
+	return verbosity
+}
+
+// SetVerbosity - Manually set the logger verbosity; must be one of:
+// * 1 - Info, Timer and Error
+// * 2 - Timer and Error
+// * 3 - Error only
+func SetVerbosity(level int) error {
+	if level < 1 && level > 3 {
+		return errors.New("Verbosity can only be set to a value of 1, 2 or 3")
+	}
+	verbosity = level
+	return nil
+}
+
+// SetOutput directs logs to a file; this disables terminal colors
 func SetOutput(w *os.File) {
 	colorEnabled = false
 	out = w

--- a/timer.go
+++ b/timer.go
@@ -5,16 +5,18 @@ import (
 	"time"
 )
 
+// Timer is a special sub-logger that records the moment of its creation, and
+// outputs time elapsed since that point when its End method is called.
 type Timer struct {
 	Logger    *Logger
 	Start     int64
 	IsEnabled bool
 }
 
+// End prints the given message and the elapsed time since the Timer was created
+// to the logger output. This does not print if the parent logger was disabled
+// at the time of the Timer's creation, even if it is subsequently enabled.
 func (t *Timer) End(format string, v ...interface{}) {
-	// Not changed to a call up to Logger.amIEnabled, because if logger wqsn't
-	// enabled by the time the Timer was created then the Timer should remain
-	// disabled. Also, Principle of Demeter, &etc.
 	if !t.IsEnabled {
 		return
 	}
@@ -25,6 +27,7 @@ func (t *Timer) End(format string, v ...interface{}) {
 	t.Logger.Write(t.Format(elapsed, fmt.Sprintf(format, v...), attrs))
 }
 
+// Format is used to create a nicely formatted timestamp and message for Timer.
 func (t *Timer) Format(elapsed int64, msg string, customAttrs *Attrs) string {
 	if !colorEnabled {
 		elapsedMS := elapsed / 1000000
@@ -42,6 +45,7 @@ func (t *Timer) Format(elapsed int64, msg string, customAttrs *Attrs) string {
 	return t.Logger.PrettyFormat(prefix, msg, customAttrs)
 }
 
+// Now is a shortcut for returning the current time in Unix nanoseconds.
 func Now() int64 {
 	return time.Now().UnixNano()
 }

--- a/timer.go
+++ b/timer.go
@@ -12,6 +12,9 @@ type Timer struct {
 }
 
 func (t *Timer) End(format string, v ...interface{}) {
+	// Not changed to a call up to Logger.amIEnabled, because if logger wqsn't
+	// enabled by the time the Timer was created then the Timer should remain
+	// disabled. Also, Principle of Demeter, &etc.
 	if !t.IsEnabled {
 		return
 	}


### PR DESCRIPTION
To make this make sense, also had to add code that checks whether
logs are enabled at call time rather than checking the value of
`IsEnabled` which is set at instantiation time. The value of IsEnabled
is updated whenever an internal method that uses it checks for
enablement.

Added a little bit of documentation to existing and new functions.