### PR TITLE
Treat -thing as thing@mute

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Another example; show error logs from all packages, but hide logs from `database
 $ LOG=*@error,database@mute go run example-app.go
 ```
 
+Another way to negate a package is to prefix it with "-". This is treated the same as package@mute:
+
+```bash
+$ LOG=*@error,-database go run example-app.go
+```
+
 ## Timers
 
 You can use timer logs for measuring your program. For example;

--- a/standard-output.go
+++ b/standard-output.go
@@ -3,11 +3,13 @@ package logger
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/azer/is-terminal"
 	"os"
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
+
+	"github.com/azer/is-terminal"
 )
 
 func NewStandardOutput(file *os.File) OutputWriter {
@@ -125,7 +127,7 @@ func (sw *StandardWriter) PrettyLabelExt(log *Log) string {
 	return ""
 }
 
-// Accepts: foo,bar,qux@timer
+// Accepts: foo,bar,qux@timer,-thing
 //          *
 //          *@error
 //          *@error,database@timer
@@ -148,7 +150,14 @@ func parsePackageSettings(input string, defaultOutputSettings *OutputSettings) m
 // Accepts: users
 //          database@timer
 //          server@error
+//          -network
 func parsePackageName(input string) (string, *OutputSettings) {
+	// Treat -thing as thing@mute
+	if strings.HasPrefix(input, "-") && !strings.Contains(input, "@") {
+		_, i := utf8.DecodeRuneInString(input)
+		input = input[i:] + "@mute"
+	}
+
 	parsed := strings.Split(input, "@")
 	name := strings.TrimSpace(parsed[0])
 


### PR DESCRIPTION
As a user of [visionmedia/debug](https://github.com/visionmedia/debug), I had expected that I could negate using "-", rather than use "mute". While mute isn't much extra effort, I keep forgetting, falling back into old habits.