### PR TITLE
Fix isTerminal call on Windows

### DIFF
--- a/standard-output.go
+++ b/standard-output.go
@@ -6,13 +6,12 @@ import (
 	"github.com/azer/is-terminal"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 )
 
 func NewStandardOutput(file *os.File) OutputWriter {
 	var writer = StandardWriter{
-		ColorsEnabled: isterminal.IsTerminal(syscall.Stderr),
+		ColorsEnabled: isterminal.IsTerminal(int(file.Fd())),
 		Target:        file,
 	}
 


### PR DESCRIPTION
On Windows `syscall.Stderr` is of type `syscall.Handle`[1] rather than `int`[2] causing a compilation error.

`github.com/azer/logger/standard-output.go:15:39: cannot use syscall.Stderr (type syscall.Handle) as type int in argument to isterminal.IsTerminal`

A simple cast to int along the lines of `isterminal.IsTerminal(int(syscall.Stderr))` would suffice although I believe it's more appropriate to check the actual output destination being passed in rather than Stderr and instead use `isterminal.IsTerminal(int(file.Fd()))`

[1] https://golang.org/pkg/syscall/?GOOS=windows#pkg-variables
[2] https://golang.org/pkg/syscall/?GOOS=linux#pkg-variables