### PR TITLE
utilize sw.Target rather than hardcoded os.Stderr

### DIFF
--- a/standard-output.go
+++ b/standard-output.go
@@ -32,7 +32,7 @@ func (standardWriter StandardWriter) Init() {}
 
 func (sw StandardWriter) Write(log *Log) {
 	if sw.IsEnabled(log.Package, log.Level) {
-		fmt.Fprintln(os.Stderr, sw.Format(log))
+		fmt.Fprintln(sw.Target, sw.Format(log))
 	}
 }
 


### PR DESCRIPTION
`StandardWriter.Target` is set[1] but not used and instead it's currently hard coded to `os.Stderr` rather than using the `os.File` that was passed in through `NewStandardOutput(file *os.File)` 



[1] https://github.com/azer/logger/blob/8b7d1ee/standard-output.go#L16